### PR TITLE
Add minor improvements for PHP setup

### DIFF
--- a/php/.gitignore
+++ b/php/.gitignore
@@ -1,2 +1,3 @@
-vendor
-.phpunit.result.cache
+/vendor
+/coverage
+*.cache

--- a/php/composer.json
+++ b/php/composer.json
@@ -10,7 +10,11 @@
     "autoload": {
         "psr-4": {
             "Kata\\": "src",
-            "Kata\\Test\\": "test"
+            "KataTests\\": "tests"
         }
+    },
+    "scripts": {
+        "test": "./vendor/bin/phpunit",
+        "test-coverage": "XDEBUG_MODE=coverage ./vendor/bin/phpunit --coverage-html coverage"
     }
 }

--- a/php/phpunit.xml
+++ b/php/phpunit.xml
@@ -1,15 +1,18 @@
 <phpunit
         bootstrap="vendor/autoload.php"
         colors="true"
+        convertErrorsToExceptions="true"
+        testdox="true"
 >
     <testsuites>
         <testsuite name="All tests">
-            <directory>tests</directory>
+            <directory suffix="Test.php">tests</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
-            <directory>src</directory>
-        </whitelist>
-    </filter>
+
+    <coverage>
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+    </coverage>
 </phpunit>

--- a/php/src/TheClass.php
+++ b/php/src/TheClass.php
@@ -1,8 +1,8 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Kata;
 
-class TheClass
+final class TheClass
 {
     public function theMethod(): bool
     {

--- a/php/src/TheClass.php
+++ b/php/src/TheClass.php
@@ -2,7 +2,7 @@
 
 namespace Kata;
 
-final class TheClass
+class TheClass
 {
     public function theMethod(): bool
     {

--- a/php/tests/MyClassTest.php
+++ b/php/tests/MyClassTest.php
@@ -5,7 +5,7 @@ namespace KataTests;
 use Kata\TheClass;
 use PHPUnit\Framework\TestCase;
 
-final class MyClassTest extends TestCase
+class MyClassTest extends TestCase
 {
     /** @test */
     public function give_me_a_good_name_please(): void

--- a/php/tests/MyClassTest.php
+++ b/php/tests/MyClassTest.php
@@ -1,11 +1,11 @@
-<?php
+<?php declare(strict_types=1);
 
-namespace Kata\Test;
+namespace KataTests;
 
 use Kata\TheClass;
 use PHPUnit\Framework\TestCase;
 
-class MyClassTest extends TestCase
+final class MyClassTest extends TestCase
 {
     /** @test */
     public function give_me_a_good_name_please(): void


### PR DESCRIPTION
# Changes
- Fix autoload tests directory. Use `tests` instead of `test`
- Change `Kata\\Test\\` to `KataTests\\` as autoload psr-4
- `testdox="true"` by default in PHPUnit
- Add some composer scripts to exec all tests and run them with coverage
- Add strict types by default to the example classes