### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
Add .gitattributes

.gitattributes prevents git from changing `lf` to`crlf` as line endings, which it does by default when commiting: https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings