### PR TITLE
Añadir ESLint a TypeScript

### DIFF
--- a/typescript/.gitignore
+++ b/typescript/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 coverage/
 package-lock.json
 yarn.lock
+yarn-error.log

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -58,6 +58,20 @@ yarn test:watch
 
 > Lanzará los tests de forma automática siempre que se modifique el código de los tests o de producción.
 
+## Buscar errores de estilo en el código
+```bash
+npm run lint
+# --- o ---
+yarn lint
+```
+
+## Corregir errores de estilo en el código
+```bash
+npm run lint:fix
+# --- o ---
+yarn lint:fix
+```
+
 # Solución de problemas
 ## No reconoce el comando `nvm`
 Si acabas de instalar nvm es posible que tengas que reiniciar el terminal para que te detecte el nuevo comando.

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -11,12 +11,15 @@
   "scripts": {
     "test": "tsc && jest",
     "coverage": "tsc && jest --coverage",
-    "test:watch": "jest --watchAll"
+    "test:watch": "jest --watchAll",
+    "lint": "ts-standard src/**/*.ts tests/**/*.ts",
+    "lint:fix": "ts-standard src/**/*.ts tests/**/*.ts --fix"
   },
   "devDependencies": {
     "@types/jest": "^29.5.0",
     "jest": "^29.5.0",
     "jest-mock-extended": "^3.0.4",
-    "ts-jest": "^29.0.5"
+    "ts-jest": "^29.0.5",
+    "ts-standard": "^12.0.2"
   }
 }

--- a/typescript/src/Example.ts
+++ b/typescript/src/Example.ts
@@ -1,5 +1,5 @@
 export class Example {
-    static method(): boolean {
-        return true
-    }
+  method (): boolean {
+    return true
+  }
 }

--- a/typescript/tests/Example.spec.ts
+++ b/typescript/tests/Example.spec.ts
@@ -1,7 +1,9 @@
 import { Example } from '../src/Example'
 
 describe('kata-setup', () => {
-    it('example test', () => {
-        expect(Example.method()).toBe(true)
-    })
+  it('example test', () => {
+    const example = new Example()
+
+    expect(example.method()).toBe(true)
+  })
 })


### PR DESCRIPTION
Las últimas katas he podido percibir que inevitablemente siempre se perdía algo de tiempo en "dejar el código bonito y a gusto de todos", esto se debe a que en las katas suele participar gente de distintos ámbitos y con distintas costumbres y obviamente no se han consensuado unas guías de estilo para un equipo que se acaba de formar.

Para centrar mas al equipo creo que es buena idea que el proyecto se ajuste a unos estilos por defecto, así el equipo no tiene que discutir y tomar micro-decisiones en cuanto a que estilos dar al código.

Además el hecho de poder aplicar estos estilos de forma automática con solo ejecutar un comando también ahorra mucho tiempo.

He instalado ts-standard, un preset de reglas para ESLint que además que te da un ESLint completamente funcional sin tener que añadir ficheros de configuración ni instalar un montón de dependencias extra para cada conjunto de reglas específicos que se quieran usar (como TypeScript, conjuntos de reglas extra, etc...).

En concreto me he decantado por standard por dos motivos:
- Son un conjunto de reglas bastante extendido (a la altura de las de Airbnb, Facebook o Google).
- Permiten su uso sin necesidad de configurar nada.

He seguido los siguientes pasos para esta tarea:
- Instalar ts-standard en el proyecto.
- Añadir 2 comandos al package.json para poder lanzar con facilidad en todo el proyecto el linter y el corrector que ofrecen esta herramienta.
- Lanzar el corrector en los ficheros que se incluyen como bootstraping para la kata.
- Añadir una definición de los 2 comandos en el README.md.