### PR TITLE
Update PHP >=8.3

### DIFF
--- a/php/composer.json
+++ b/php/composer.json
@@ -2,12 +2,12 @@
     "name": "kata-setup/php",
     "description": "Initial code to start TDD katas",
     "require": {
-        "php": ">=8.2"
+        "php": ">=8.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10",
+        "phpunit/phpunit": "^12",
         "infection/codeception-adapter": "^0.4",
-        "infection/infection": "^0.27"
+        "infection/infection": "^0.31"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
### 📚 Description

Active support for PHP 8.2 ended on January 1, 2025. This PR aims to update the minimum PHP version to 8.3.

<img width="1353" height="766" alt="image" src="https://github.com/user-attachments/assets/ddc427cf-674a-4d25-afee-9d2c8216bfa1" />

src: https://www.php.net/supported-versions.php